### PR TITLE
Back protection

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -5,7 +5,7 @@ class ClientsController < ApplicationController
   # GET /clients
   def index
     if params[:society_id]
-        @clients = Client.where(society_id: params[:society_id])
+        @clients = current_user.societies.find(params[:society_id]).clients
         render json: @clients, include: :invoices
       else
         render json: { error: "Unauthorized" }, status: :unauthorized

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -19,7 +19,9 @@ class ClientsController < ApplicationController
 
   # POST /clients
   def create
-    @client = Client.new(client_params)
+    @client = Client.new(client_params.except(:user_id, :society_id))
+    @client.user = current_user
+    @client.society = current_user.societies.find(params[:society_id])
 
     if @client.save
       render json: @client, status: :created, location: @client
@@ -30,7 +32,7 @@ class ClientsController < ApplicationController
 
   # PATCH/PUT /clients/1
   def update
-    if @client.update(client_params)
+    if @client.update(client_params.except(:user_id, :society_id))
       render json: @client
     else
       render json: @client.errors, status: :unprocessable_entity

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -1,4 +1,5 @@
 class ClientsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_client, only: %i[ show update destroy ]
 
   # GET /clients
@@ -45,6 +46,9 @@ class ClientsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_client
       @client = Client.find(params[:id])
+      if current_user.id != @client.user_id
+        return render json: { error: "Unauthorized" }, status: :unauthorized
+      end
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -5,7 +5,7 @@ class InvoicesController < ApplicationController
   # GET /invoices
   def index
     if params[:society_id]
-        @invoices = Invoice.where(society_id: params[:society_id])
+        @invoices = current_user.invoices.where(society_id: params[:society_id])
         render json: @invoices
       else
         render json: { error: "Unauthorized" }, status: :unauthorized
@@ -19,7 +19,7 @@ class InvoicesController < ApplicationController
 
   # POST /invoices
   def create
-    @invoice = Invoice.new(invoice_params.except(:client_infos))
+    @invoice = Invoice.new(invoice_params.except(:client_infos, :society_infos))
     @invoice.user = current_user
 
     if invoice_params.include?(:society_id)

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -58,7 +58,7 @@ class InvoicesController < ApplicationController
       @invoice.society.update!(invoice_params[:society_infos])
     end
 
-    if @invoice.update(invoice_params.except(:client_infos))
+    if @invoice.update(invoice_params.except(:client_infos, :society_infos))
       render json: @invoice
     else
       render json: @invoice.errors, status: :unprocessable_entity

--- a/app/controllers/societies_controller.rb
+++ b/app/controllers/societies_controller.rb
@@ -17,7 +17,8 @@ class SocietiesController < ApplicationController
 
   # POST /societies
   def create
-    @society = Society.new(society_params)
+    @society = Society.new(society_params.except(:user_id))
+    @society.user = current_user
 
     if @society.save
       render json: @society, status: :created, location: @society

--- a/app/controllers/societies_controller.rb
+++ b/app/controllers/societies_controller.rb
@@ -5,19 +5,14 @@ class SocietiesController < ApplicationController
 
   # GET /societies
   def index
-    @societies = Society.where(user: current_user)
+    @societies = current_user.societies
 
     render json: @societies
   end
 
   # GET /societies/1
   def show
-    @society = Society.find(params[:id])
-    if user_signed_in? && @society.user_id == current_user.id
-      render json: @society
-    else
-      render json: { error: 'Unauthorized' }, status: :unauthorized
-    end
+    render json: @society
   end
 
   # POST /societies
@@ -60,6 +55,10 @@ class SocietiesController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_society
       @society = Society.find(params[:id])
+
+      if @society.user_id != current_user.id
+        return render json: { error: "Unauthorized" }, status: :unauthorized
+      end
     end
 
     # Only allow a list of trusted parameters through.


### PR DESCRIPTION
Added protections to controllers :
- only authenticate users
- only owner of the object is allowed
- prevent identity theft by selecting current_user (bearer token) as owner when update or creation && selecting only objects from the current_user
  - eg: for society, we select the society of the current_user that matches the society_id from the request